### PR TITLE
Update Dockerfile baked-pdf references to mathify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ##
 ## Create an image that can be used to play with
-## baked-pdf commands.
+## mathify commands.
 ##
 ## To create the image:
-##    docker build -t openstax/cnx-bakedpdf:latest .
+##    docker build -t openstax/mathify:latest .
 ##
 ## To start the container:
-##    docker run --mount type=bind,source=$(pwd),target=/src -it openstax/cnx-bakedpdf:latest /bin/bash
-## where the baked-pdf repo has been cloned into the
+##    docker run --mount type=bind,source=$(pwd),target=/src -it openstax/mathify:latest /bin/bash
+## where the mathify repo has been cloned into the
 ## current working directory.
 ##
 ## To run the code:
@@ -16,7 +16,7 @@
 ## where <X> are filenames, e.g.:
 ##    node start -i ../test-simple.xhtml -o output.html
 ## See:
-##    https://github.com/openstax/baked-pdf
+##    https://github.com/openstax/mathify
 ## for details.
 ##
 


### PR DESCRIPTION
We thought of using this repo to do the baked pdf CLI but we have gone
down a different path.  A few weeks ago, we renamed this repo from
baked-pdf to mathify.  `Dockerfile` needs to be updated so users don't
get confused.