### PR TITLE
Add fallback information to svg font data

### DIFF
--- a/typeset/mjnode.js
+++ b/typeset/mjnode.js
@@ -33,7 +33,7 @@ const convertMathML = async (log, mathMap/*: Map<string, {xml: string, fontSize:
         noReflows: false
       },
       SVG: {
-        font: 'STIX-Web',
+        font: 'STIXIntegralsUp',
         // mtextFontInherit: true,
         // Add fallback information to font-data:
         // https://github.com/mathjax/MathJax/issues/1091#issuecomment-269653429

--- a/typeset/mjnode.js
+++ b/typeset/mjnode.js
@@ -33,8 +33,46 @@ const convertMathML = async (log, mathMap/*: Map<string, {xml: string, fontSize:
         noReflows: false
       },
       SVG: {
-        font: 'STIX-Web'
+        font: 'STIX-Web',
         // mtextFontInherit: true,
+        // Add fallback information to font-data:
+        // https://github.com/mathjax/MathJax/issues/1091#issuecomment-269653429
+        Argument: {
+          initSVG: function(math, span) {
+            if (this.config.font !== "TeX") {
+              this.Augment({
+                lookupChar_old: this.lookupChar,
+                lookupChar: function (variant,n) {
+                  do {
+                    var char = this.lookupChar_old(variant,n);
+                    if (char.id !== "unknown") return char;
+                    variant = VARIANT[variant.chain];
+                  } while (variant);
+                  return char;
+                }
+              });
+              var VARIANT = this.FONTDATA.VARIANT;
+              VARIANT["bold"].chain = "normal";
+              VARIANT["italic"].chain = "normal";
+              VARIANT["bold-italic"].chain = "bold";
+              VARIANT["double-struck"].chain = "normal";
+              VARIANT["fraktur"].chain = "normal";
+              VARIANT["bold-fraktur"].chain = "bold";
+              VARIANT["script"].chain = "normal";
+              VARIANT["bold-script"].chain = "bold";
+              VARIANT["sans-serif"].chain = "normal";
+              VARIANT["bold-sans-serif"].chain = "bold";
+              VARIANT["sans-serif-italic"].chain = "italic";
+              VARIANT["sans-serif-bold-italic"].chain = "bold-italic";
+              VARIANT["monospace"].chain = "normal";
+              VARIANT["-tex-caligraphic"].chain = "normal";
+              VARIANT["-tex-oldstyle"].chain = "normal";
+              VARIANT["-tex-caligraphic-bold"].chain = "bold";
+              VARIANT["-tex-oldstyle-bold"].chain = "bold";
+            }
+            this.initSVG = function (math,span) {}
+          }
+        }
       }
     }
   })


### PR DESCRIPTION
Several users reported errors when running mathify on certain books
including intermediate-algebra, u-physics, apphyics:

```
SVG - Unknown character: U+200B in STIXMathJax_Main,STIXMathJax_Monospace,STIXMathJax_Latin,STIXMathJax_Alphabets,STIXMathJax_Marks,STIXMathJax_Arrows,STIXMathJax_Operators,STIXMathJax_Symbols,STIXMathJax_Shapes,STIXMathJax_Misc,STIXMathJax_Variants,STIXMathJax_Size1
...
SVG - Unknown character: U+221E in STIXMathJax_Main-italic,STIXMathJax_Normal-italic,STIXMathJax_Script-italic,STIXMathJax_DoubleStruck-italic,STIXMathJax_SansSerif-italic,STIXMathJax_Latin-italic,STIXMathJax_Alphabets-italic,STIXMathJax_Marks-italic,STIXMathJax_Misc-italic,STIXMathJax_Variants-italic,STIXMathJax_Size1
SVG - Unknown character: U+221E in STIXMathJax_Main-italic,STIXMathJax_Normal-italic,STIXMathJax_Script-italic,STIXMathJax_DoubleStruck-italic,STIXMathJax_SansSerif-italic,STIXMathJax_Latin-italic,STIXMathJax_Alphabets-italic,STIXMathJax_Marks-italic,STIXMathJax_Misc-italic,STIXMathJax_Variants-italic,STIXMathJax_Size1
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 0x8dc510 node::Abort() [node]
...
23: 0xba9121 v8::internal::Builtin_JsonStringify(int, v8::internal::Object**, v8::internal::Isolate*) [node]
24: 0x33ae8585bf7d
/bin/bash: line 1:     7 Aborted                 (core dumped) node typeset/start -i '/out/collection.baked.xhtml' -o '/out/collection.mathified.xhtml' -f svg
```

This fixes the "Unknown character" errors.