### PR TITLE
Change SVG font to STIXIntegralsUp

### DIFF
--- a/typeset/mjnode.js
+++ b/typeset/mjnode.js
@@ -33,7 +33,7 @@ const convertMathML = async (log, mathMap/*: Map<string, {xml: string, fontSize:
         noReflows: false
       },
       SVG: {
-        font: 'STIX-Web',
+        font: 'STIXIntegralsUp',
         // mtextFontInherit: true,
         // Add fallback information to font-data:
         // https://github.com/mathjax/MathJax/issues/1091#issuecomment-269653429


### PR DESCRIPTION
STIXIntegralsUp is the font we decided to use when doing the Math spike.
See Helene's document here:

https://docs.google.com/document/d/1OY8fAZl3G8Sk5cly4iE4xa6F1qZ_JyjPaJTidlfk22Q/edit?pli=1#heading=h.hp2kb6pkc379