### PR TITLE
Fix mathjax format MathML / inline-TeX detection

### DIFF
--- a/typeset/mjnode.js
+++ b/typeset/mjnode.js
@@ -87,14 +87,16 @@ const convertMathML = async (log, mathEntries/* [{xml: string, fontSize: number}
   const promises = mathEntries.map(({xml: mathSource, fontSize}) => {
     const id = done + index
     index++
-    return mjAPI.typeset({
+    const typesetConfig = {
       math: mathSource,
-      format: mathSource[0] !== '\\' ? 'MathML' : 'inline-TeX', // "inline-TeX", "TeX", "MathML"
+      format: mathSource.match('^<([^:]+:)?math') ? 'MathML' : 'inline-TeX', // "inline-TeX", "TeX", "MathML"
       svg: outputFormat === 'svg',
       html: outputFormat === 'html',
       css: outputFormat === 'html',
       ex: fontSize
-    })
+    }
+    log.debug(`Typeset config: ${JSON.stringify(typesetConfig)}`)
+    return mjAPI.typeset(typesetConfig)
       .then((result) => {
         const {errors, svg, css} = result
         let {html} = result // later, remove &nbsp; since it is not valid XHTML


### PR DESCRIPTION
Mathify looks for all `<math>` elements and elements with the
`data-math` attribute for conversion using mathjax.  All the `<math>`
elements should use "MathML" and all the elements with the `data-math`
attribute should use "inline-TeX" as the format when using the mathjax
API.  The old logic decides it's "inline-TeX" only if the math starts
with a backslash.  It works for math like `\text{W}" but not for
"E = mc^{2}".

So instead of checking if the math starts with a backslash, I changed it
to check if the math starts with a `<([^:]+:)?math`, and if it does, it's "MathML"
and if it doesn't, it's "inline-TeX".  This works for hsphysics
(col10002 on content04).