### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,24 +20,9 @@
 ## for details.
 ##
 
-FROM ubuntu:latest as baseline
-WORKDIR /
-RUN apt-get update
-RUN apt-get -y install curl
-RUN apt-get -y install ed
-RUN apt-get -y install git
-RUN apt-get -y install vim
-RUN apt-get -y install gnupg
-RUN apt-get -y install make
-RUN apt-get -y install build-essential
-RUN apt-get -y install libx11-dev
-## from: https://github.com/GoogleChrome/puppeteer/issues/404
-RUN apt-get -y install libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 libgconf2-4 libasound2 libatk1.0-0 libgtk-3-0
-
-FROM baseline as install-node
-WORKDIR /
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get install -y nodejs
+FROM node:10
+RUN apt update
+RUN apt -y install libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 libasound2 libatk1.0-0 libgtk-3-0
 
 COPY . /src
 WORKDIR /src/


### PR DESCRIPTION
Also removes libgconf2-4 since it is no longer available in apt, and seems to no longer be needed (tests pass without it).