### PR TITLE
Better latex error logging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,24 +3,21 @@ name: tests
 on:
   pull_request:
   push:
-    branches:
-      - main
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0' # weekly
 jobs:
   tests:
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '12'
+          node-version: '18'
       - name: Setup
         run: |
-          npm install -g codecov
           npm install
       - name: Test
         run: |
           npm run-script test
-          codecov

--- a/typeset/converter.js
+++ b/typeset/converter.js
@@ -18,17 +18,17 @@ const STATUS_CODE = {
 }
 
 const makeMathErrorHandler = (xmlPath, log) => (errorPairs) => {
-  const xmlString = fs.readFileSync(xmlPath, { encoding: 'utf-8' });
-  const xmlDoc = parseXML(xmlString, 'text/html');
-  const elements = Object.values(xmlDoc.getElementsByTagName('*'));
+  const xmlString = fs.readFileSync(xmlPath, { encoding: 'utf-8' })
+  const xmlDoc = parseXML(xmlString, 'text/html')
+  const elements = Object.values(xmlDoc.getElementsByTagName('*'))
   errorPairs.forEach(([err, match]) => {
-    const matchInfo = { errors: err };
-    const { attributes } = match.node;
-    let element;
+    const matchInfo = { errors: err }
+    const { attributes } = match.node
+    let element
     // TODO: Ideally this would work for mathml elements too
     if ('data-math' in attributes) {
-      const dataMath = attributes['data-math'];
-      element = elements.find((el) => el.getAttribute('data-math') === dataMath);
+      const dataMath = attributes['data-math']
+      element = elements.find((el) => el.getAttribute('data-math') === dataMath)
     }
     // If we found an element, walk up the tree and try to gather useful information
     if (element) {
@@ -37,17 +37,17 @@ const makeMathErrorHandler = (xmlPath, log) => (errorPairs) => {
         'data-math',
         'data-injected-from-url',
         'data-injected-from-nickname',
-        'data-injected-from-version',
-      ];
+        'data-injected-from-version'
+      ]
       for (const el of ancestorOrSelf(element)) {
         targetAttributes.forEach((attrName) => {
-          matchInfo[attrName] = matchInfo[attrName] || el.getAttribute(attrName);
+          matchInfo[attrName] = matchInfo[attrName] || el.getAttribute(attrName)
         })
-        if (matchInfo['data-sm']) break;
+        if (matchInfo['data-sm']) break
       }
     }
-    log.error(JSON.stringify(matchInfo, Object.keys(matchInfo).filter((k) => matchInfo[k]), 2));
-  });
+    log.error(JSON.stringify(matchInfo, Object.keys(matchInfo).filter((k) => matchInfo[k]), 2))
+  })
 }
 
 const createMapOfMathMLElements = async (log, inputPath, cssPath, outputPath, outputFormat, batchSize, highlight) => {
@@ -143,12 +143,12 @@ const createMapOfMathMLElements = async (log, inputPath, cssPath, outputPath, ou
   await highlightCodeElements(codeEntries)
 
   const allUniqueCss = new Set()
-  const handleErrors = makeMathErrorHandler(inputPath, log);
+  const handleErrors = makeMathErrorHandler(inputPath, log)
   for (let batch = 0; batch < Math.ceil(mathEntries.length / batchSize); batch++) {
     const start = batchSize * batch
     const end = Math.min(batchSize * batch + batchSize, mathEntries.length)
     log.info(`Converting math elements ${start} to ${end} of ${mathEntries.length}`)
-    const uniqueCss = await mjnodeConverter.convertMathML(log, mathEntries.slice(start, end), outputFormat, mathEntries.length, start, handleErrors);
+    const uniqueCss = await mjnodeConverter.convertMathML(log, mathEntries.slice(start, end), outputFormat, mathEntries.length, start, handleErrors)
     allUniqueCss.add(uniqueCss)
   }
 

--- a/typeset/converter.js
+++ b/typeset/converter.js
@@ -17,8 +17,8 @@ const STATUS_CODE = {
   ERROR: 111
 }
 
-const makeMathErrorHandler = (xmlPath, log) => (errorPairs) => {
-  const xmlString = fs.readFileSync(xmlPath, { encoding: 'utf-8' })
+const makeMathErrorHandler = (inputPath, log) => (errorPairs) => {
+  const xmlString = fs.readFileSync(inputPath, { encoding: 'utf-8' })
   const xmlDoc = parseXML(xmlString, 'text/html')
   const elements = Object.values(xmlDoc.getElementsByTagName('*'))
   errorPairs.forEach(([err, match]) => {

--- a/typeset/converter.js
+++ b/typeset/converter.js
@@ -22,7 +22,7 @@ const makeMathErrorHandler = (inputPath, log) => (errorPairs) => {
   const xmlDoc = parseXML(xmlString, 'text/html')
   const elements = Object.values(xmlDoc.getElementsByTagName('*'))
   errorPairs.forEach(([err, match]) => {
-    const matchInfo = { errors: err }
+    const matchInfo = { errors: err, tagName: match.node.name }
     const { attributes } = match.node
     let element
     // TODO: Ideally this would work for mathml elements too

--- a/typeset/dom-utils.js
+++ b/typeset/dom-utils.js
@@ -1,0 +1,44 @@
+const { DOMParser } = require('@xmldom/xmldom');
+
+const ELEMENT_NODE = 1;
+
+function getParentElement(node) {
+  let ptr = node.parentNode;
+  while (ptr && ptr.nodeType !== ELEMENT_NODE) {
+    ptr = ptr.parentNode;
+  }
+  return ptr;
+}
+
+function* ancestorOrSelf(node) {
+  let ptr = node;
+  while (ptr) {
+    yield ptr;
+    ptr = getParentElement(ptr);    
+  }
+}
+
+class ParseError extends Error { }
+
+function parseXML(xmlString, mimetype) {
+  const locator = { lineNumber: 0, columnNumber: 0 }
+  const cb = /* istanbul ignore next */ () => {
+    const pos = {
+      line: locator.lineNumber - 1,
+      character: locator.columnNumber - 1
+    }
+    throw new ParseError(`ParseError: ${JSON.stringify(pos)}`)
+  }
+  const p = new DOMParser({
+    locator,
+    errorHandler: {
+      warning: console.warn,
+      error: cb,
+      fatalError: cb
+    }
+  })
+  const doc = p.parseFromString(xmlString, mimetype)
+  return doc
+}
+
+module.exports = { ancestorOrSelf, getParentElement, ParseError, parseXML };

--- a/typeset/dom-utils.js
+++ b/typeset/dom-utils.js
@@ -1,26 +1,26 @@
-const { DOMParser } = require('@xmldom/xmldom');
+const { DOMParser } = require('@xmldom/xmldom')
 
-const ELEMENT_NODE = 1;
+const ELEMENT_NODE = 1
 
-function getParentElement(node) {
-  let ptr = node.parentNode;
+function getParentElement (node) {
+  let ptr = node.parentNode
   while (ptr && ptr.nodeType !== ELEMENT_NODE) {
-    ptr = ptr.parentNode;
+    ptr = ptr.parentNode
   }
-  return ptr;
+  return ptr
 }
 
-function* ancestorOrSelf(node) {
-  let ptr = node;
+function * ancestorOrSelf (node) {
+  let ptr = node
   while (ptr) {
-    yield ptr;
-    ptr = getParentElement(ptr);    
+    yield ptr
+    ptr = getParentElement(ptr)
   }
 }
 
 class ParseError extends Error { }
 
-function parseXML(xmlString, mimetype) {
+function parseXML (xmlString, mimetype) {
   const locator = { lineNumber: 0, columnNumber: 0 }
   const cb = /* istanbul ignore next */ () => {
     const pos = {
@@ -41,4 +41,4 @@ function parseXML(xmlString, mimetype) {
   return doc
 }
 
-module.exports = { ancestorOrSelf, getParentElement, ParseError, parseXML };
+module.exports = { ancestorOrSelf, getParentElement, ParseError, parseXML }

--- a/typeset/mjnode.js
+++ b/typeset/mjnode.js
@@ -87,7 +87,7 @@ const convertMathML = async (log, mathEntries, outputFormat, total, done, handle
   let numDone = done
   const convertedCss = new Set()
   let index = 0
-  const errorPairs = [];
+  const errorPairs = []
   const promises = mathEntries.map(entry => {
     const id = done + index
     const mathSource = entry.mathSource
@@ -130,13 +130,13 @@ const convertMathML = async (log, mathEntries, outputFormat, total, done, handle
         if (css != null) {
           convertedCss.add(css)
         }
-      }).catch((err) => { errorPairs.push([err, entry]); })
+      }).catch((err) => { errorPairs.push([err, entry]) })
   })
 
-  await Promise.all(promises);
+  await Promise.all(promises)
   if (errorPairs.length > 0) {
-    handleErrors(errorPairs);
-    throw new Error('An error occurred while converting math.');
+    handleErrors(errorPairs)
+    throw new Error('An error occurred while converting math.')
   }
   log.info(`Converted ${numDone} elements.`)
   return [...convertedCss.keys()]

--- a/typeset/mjnode.js
+++ b/typeset/mjnode.js
@@ -76,7 +76,7 @@ const startAPI = (log) => {
   mjStarted = true
 }
 
-const convertMathML = async (log, mathEntries, outputFormat, total, done) => {
+const convertMathML = async (log, mathEntries, outputFormat, total, done, handleErrors) => {
   if (!mjStarted) {
     startAPI(log)
   }
@@ -87,6 +87,7 @@ const convertMathML = async (log, mathEntries, outputFormat, total, done) => {
   let numDone = done
   const convertedCss = new Set()
   let index = 0
+  const errorPairs = [];
   const promises = mathEntries.map(entry => {
     const id = done + index
     const mathSource = entry.mathSource
@@ -129,10 +130,14 @@ const convertMathML = async (log, mathEntries, outputFormat, total, done) => {
         if (css != null) {
           convertedCss.add(css)
         }
-      })
+      }).catch((err) => { errorPairs.push([err, entry]); })
   })
 
-  await Promise.all(promises)
+  await Promise.all(promises);
+  if (errorPairs.length > 0) {
+    handleErrors(errorPairs);
+    throw new Error('An error occurred while converting math.');
+  }
   log.info(`Converted ${numDone} elements.`)
   return [...convertedCss.keys()]
 }

--- a/typeset/tests/dom-utils.test.js
+++ b/typeset/tests/dom-utils.test.js
@@ -1,0 +1,22 @@
+const { ancestorOrSelf, parseXML } = require('../dom-utils')
+
+describe('ancestorOrSelf', () => {
+  it('stops gracefully', () => {
+    const xmlStr = `
+  <root>
+    <a>
+      <b>
+        stuff
+      </b>
+    </a>
+  </root>
+  `
+    const tree = parseXML(xmlStr)
+    const b = Object.values(tree.getElementsByTagName('b'))[0]
+    expect(b).toBeDefined();
+    const visited = Array.from(ancestorOrSelf(b));
+    expect(visited.map((node) => node.tagName)).toStrictEqual([
+      'b', 'a', 'root'
+    ])
+  })
+})

--- a/typeset/tests/dom-utils.test.js
+++ b/typeset/tests/dom-utils.test.js
@@ -13,8 +13,8 @@ describe('ancestorOrSelf', () => {
   `
     const tree = parseXML(xmlStr)
     const b = Object.values(tree.getElementsByTagName('b'))[0]
-    expect(b).toBeDefined();
-    const visited = Array.from(ancestorOrSelf(b));
+    expect(b).toBeDefined()
+    const visited = Array.from(ancestorOrSelf(b))
     expect(visited.map((node) => node.tagName)).toStrictEqual([
       'b', 'a', 'root'
     ])

--- a/typeset/tests/seed/test-latex-errors.xhtml
+++ b/typeset/tests/seed/test-latex-errors.xhtml
@@ -1,0 +1,18 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML">
+  <head itemscope="itemscope" itemtype="http://schema.org/Book"></head>
+  <body itemscope="itemscope" itemtype="http://schema.org/Book">
+        <div data-sm="./some-document" data-injected-from-nickname="broken-exercise" data-type="note" data-has-label="true" id="fs-id1425951" class="interactive ost-assessed-feature ui-has-child-title" data-label=""><header><div data-type="title" data-label-parent="">Link to Learning</div></header><section><span data-type="media" id="fs-id1712253" data-alt="QR Code representing a URL"></span>
+          <p>Some element</p>
+          <div data-type="exercise" id="fs-id1167065847818" class="os-exercise unnumbered" data-label=""><section>
+            <div data-type="problem" id="fs-id1167065876779">
+              <div>Text that should not matter</div>
+              <ol data-number-style="lower-alpha">
+                <li><span data-math="\left\{\begin{array}{l}3x+7y=15\3x+7y=40\end{array}\right.">MATH</span></li>
+                <li><span data-math="\text{H^+">MATH</span></li>
+              </ol>
+            
+            </div>
+            </section></div>
+            </section></div>
+  </body>
+</html>

--- a/typeset/tests/typeset.test.js
+++ b/typeset/tests/typeset.test.js
@@ -188,6 +188,7 @@ test('Error logging', async (done) => {
   \"errors\": [
     \"TeX parse error: Undefined control sequence \\\\3\"
   ],
+  \"tagName\": \"span\",
   \"data-sm\": \"./some-document\",
   \"data-math\": \"\\\\left\\\\{\\\\begin{array}{l}3x+7y=15\\\\3x+7y=40\\\\end{array}\\\\right.\",
   \"data-injected-from-nickname\": \"broken-exercise\"
@@ -196,6 +197,7 @@ test('Error logging', async (done) => {
   \"errors\": [
     \"TeX parse error: Missing close brace\"
   ],
+  \"tagName\": \"span\",
   \"data-sm\": \"./some-document\",
   \"data-math\": \"\\\\text{H^+\",
   \"data-injected-from-nickname\": \"broken-exercise\"

--- a/typeset/tests/typeset.test.js
+++ b/typeset/tests/typeset.test.js
@@ -172,16 +172,16 @@ test('Convert inline code tags and block pre tags', async (done) => {
 }, 3000)
 
 test('Error logging', async (done) => {
-  const messages = [];
+  const messages = []
   const logCapture = {
     info: jest.fn(),
     debug: jest.fn(),
-    error: jest.fn().mockImplementation(messages.push.bind(messages)),
-  };
+    error: jest.fn().mockImplementation(messages.push.bind(messages))
+  }
   await expect(
     converter.createMapOfMathMLElements(logCapture, pathToInputLatexErrors, pathToCss, pathToOutputMML, 'mathml', 3000, true)
   ).rejects.toThrow()
-  
+
   expect(messages).toStrictEqual(
     [
 `{

--- a/typeset/tests/typeset.test.js
+++ b/typeset/tests/typeset.test.js
@@ -18,6 +18,7 @@ const pathToCss = path.resolve('./typeset/tests/seed/test.css')
 const pathToOutput = path.resolve('./typeset/tests/test-output.xhtml')
 const pathToOutputSVG = path.resolve('./typeset/tests/test-output-svg.xhtml')
 const pathToInputLatex = path.resolve('./typeset/tests/seed/test-latex.xhtml')
+const pathToInputLatexErrors = path.resolve('./typeset/tests/seed/test-latex-errors.xhtml')
 const pathToOutputLatex = path.resolve('./typeset/tests/test-output-latex.xhtml')
 const pathToOutputMML = path.resolve('./typeset/tests/test-output-mathml.xhtml')
 
@@ -169,3 +170,38 @@ test('Convert inline code tags and block pre tags', async (done) => {
   expect(fs.readFileSync(pathToCodeOutput, 'utf-8')).toMatchSnapshot()
   done()
 }, 3000)
+
+test('Error logging', async (done) => {
+  const messages = [];
+  const logCapture = {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn().mockImplementation(messages.push.bind(messages)),
+  };
+  await expect(
+    converter.createMapOfMathMLElements(logCapture, pathToInputLatexErrors, pathToCss, pathToOutputMML, 'mathml', 3000, true)
+  ).rejects.toThrow()
+  
+  expect(messages).toStrictEqual(
+    [
+`{
+  \"errors\": [
+    \"TeX parse error: Undefined control sequence \\\\3\"
+  ],
+  \"data-sm\": \"./some-document\",
+  \"data-math\": \"\\\\left\\\\{\\\\begin{array}{l}3x+7y=15\\\\3x+7y=40\\\\end{array}\\\\right.\",
+  \"data-injected-from-nickname\": \"broken-exercise\"
+}`,
+`{
+  \"errors\": [
+    \"TeX parse error: Missing close brace\"
+  ],
+  \"data-sm\": \"./some-document\",
+  \"data-math\": \"\\\\text{H^+\",
+  \"data-injected-from-nickname\": \"broken-exercise\"
+}`
+    ]
+  )
+
+  done()
+}, 30000)


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-965

Try to include additional information about TeX errors. 

Before, errors would look like:
```
TeX parse error: Undefined control sequence \3
TeX parse error: Missing close brace
```

With this change, errors should look like (with additional information where available):
```
{
  "errors": [
    "TeX parse error: Undefined control sequence \\3"
  ],
  "data-sm": "./some-document",
  "data-math": "\\left\\{\\begin{array}{l}3x+7y=15\\3x+7y=40\\end{array}\\right.",
  "data-injected-from-nickname": "broken-exercise"
}
{
  "errors": [
    "TeX parse error: Missing close brace"
  ],
  "data-sm": "./some-document",
  "data-math": "\\text{H^+",
  "data-injected-from-nickname": "broken-exercise"
}
```

## Questions I Suspect People might ask

Q: Why do you need to parse the document when reporting these errors?
A: The simplest way to gather information was to walk up the DOM tree from the matching element. During normal operation, there is no DOM tree, just a flat list of element matches. The error handler should only parse the document into a DOM tree when there are errors that need explaining.

Q: Why not just use a DOM tree all the time in mathify?
A: Mathify did use a DOM tree and xpath in the past, but it was regularly using > 8GiB of memory and causing OOM errors. That was partially due to how it was replacing elements in the past. I do not think it will be a problem when reporting errors.

Q: You are using `find` to find the element by `data-math`. What if more than one element matches? Find only returns the first.
A: Yeah, that could happen, but (a) it's unlikely and (b) all matching elements would contain the same error. If it's more of a problem than I suspect, then a possible solution would be to use `matchInfo` as a hash to ensure each element is only reported once.

Q: What is `data-sm` and why stop climbing the tree there?
A: `data-sm` is a relative path to the original cnxml module with line and column number. These will automatically link back to the element in the github repository when the error is viewed in CORGI. Since this is about as specific as you can get, it seemed like a good place to stop. Granted, `data-sm` is only available in CORGI and local, not in the webhosting pipeline. If there are TeX errors in webhosting, which really shouldn't happen, then it will climb all the way to the top of tree and stop gracefully.